### PR TITLE
fix: correctly expose not and attr from filter-conditions

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -6,5 +6,6 @@ export * from './operators';
 export { PaginationMode };
 export { IFilterConditions } from './build-keys';
 export { IPaginatedResult, PageReceivedHook } from './operation';
+export { attr, not } from './filter-conditions';
 
 export default Model;


### PR DESCRIPTION
Related to issue #277

Correctly expose not and attr function from filter-conditions files to avoid import from `dynamodels/dist/src/filter-conditions` for consumers.